### PR TITLE
DINFRA-513: SF JDBC jar added, jdbc_ metric prefix removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ojdbc8.jar
 pom.xml.releaseBackup
 release.properties
+target/*

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>junit</artifactId>
             <version>4.13</version>
         </dependency>
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-jdbc</artifactId>
+            <version>3.12.13</version>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfig.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfig.java
@@ -279,7 +279,7 @@ class JdbcConfig {
       throws SQLException {
     List<Collector.MetricFamilySamples.Sample> samples = new ArrayList<>();
 
-    final String queryName = String.format("jdbc_%s", query.name);
+    final String queryName = String.format("%s", query.name);
     while (rs.next()) {
       List<String> labelValues =
           query.labels


### PR DESCRIPTION
In scope of this PR:
- Snowflake JDBC dependency added
- `jdbc_` prix removed from the metric name
- .gitignore updated 